### PR TITLE
V2/11 automatically run tests

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -1,10 +1,6 @@
 run-name: Run all Linux Factory tests for branch ${{ github.ref_name }}
 
 on:
-  pull_request:
-    branches:
-      - releases/v1
-      - releases/v2
   push:
     branches:
       - v1/**

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -1,4 +1,4 @@
-name: Run all Linux Factory tests for branch ${{ github.ref_name }}
+run-name: Run all Linux Factory tests for branch ${{ github.ref_name }}
 
 on:
   pull_request:

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -1,0 +1,34 @@
+name: Run all Linux Factory tests for branch ${{ github.ref_name }}
+
+on:
+  pull_request:
+    branches:
+      - releases/v1
+      - releases/v2
+  push:
+    branches:
+      - v1/**
+      - v2/**
+
+jobs:
+  test-clayrisser-v1:
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/v1/')) ||
+      (github.event_name == 'pull_request' && github.base_ref == 'releases/v1')
+    uses: cnshing/build-linux-factory/.github/workflows/test-clayrisser-linux-factory.yml@test-releases/v1
+
+  test-clayrisser-v2:
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/v2/')) ||
+      (github.event_name == 'pull_request' && github.base_ref == 'releases/v2')
+    uses: cnshing/build-linux-factory/.github/workflows/test-clayrisser-linux-factory.yml@test-releases/v2
+    with:
+      branch: ${{ github.ref_name }}
+
+  test-cnshing-v2:
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/v2/')) ||
+      (github.event_name == 'pull_request' && github.base_ref == 'releases/v2')
+    uses: cnshing/build-linux-factory/.github/workflows/test-cnshing-debian-livecd.yml@test-releases/v2
+    with:
+      branch: ${{ github.ref_name }}


### PR DESCRIPTION
This PR aims to add a proper test run that automatically runs the appropriate test based off the version release being tested. It assumes the branches follow a `v+d/...` match where the branch name must has `v1` or `v2`. Unfortunately due to how reuseable workflows currently work, each test case and version must be directly enumerated. 