### PR TITLE
V2/18 outdated test action workflows are being run on push

### DIFF
--- a/.github/workflows/test-clayrisser-linux-factory.yml
+++ b/.github/workflows/test-clayrisser-linux-factory.yml
@@ -1,11 +1,11 @@
-run-name: Test build-linux-factory v1 action on clayrisser's linux factory
+run-name: Dummy test workflow for build-linux-factory
 
 on:
   workflow_dispatch:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - name: Dummy workflow
-        run: echo "This is a dummy workflow"
-      
+        run: echo "::warning If you are seeing this message, then this means you are running a test workflow outside the designated test branches.""

--- a/.github/workflows/test-cnshing-debian-livecd.yml
+++ b/.github/workflows/test-cnshing-debian-livecd.yml
@@ -1,11 +1,11 @@
-run-name: Test build-linux-factory v1 action on clayrisser's linux factory
+run-name: Dummy test workflow for build-linux-factory
 
 on:
   workflow_dispatch:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - name: Dummy workflow
-        run: echo "This is a dummy workflow"
-      
+        run: echo "::warning If you are seeing this message, then this means you are running a test workflow outside the designated test branches.""


### PR DESCRIPTION
This quick fix updates the test workflows to be syntactically valid with a corrected dummy message, in hopes of preventing the workflow from being run directly on push. 