### PR TITLE
V2/15 support debian livebuild caching in GitHub actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ runs:
       run: sudo env "PATH=$PATH" make build
 
     - name: Recursively list all directories # Temporary command to list all possible files
-      working-directory: ./${{ inputs.path }}
+      working-directory: .
       shell: bash
       run: |
         sudo apt-get install -y tree

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,13 @@ runs:
       shell: bash
       run: sudo env "PATH=$PATH" make build
 
+    - name: Recursively list all directories # Temporary command to list all possible files
+      working-directory: ./${{ inputs.path }}
+      shell: bash
+      run: |
+        sudo apt-get install -y tree
+        tree
+
     - name: Output ISO Path
       id: iso-path
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get install -y tree
-        tree
+        tree -a
 
     - name: Output ISO Path
       id: iso-path

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
 
-    # Cache downloaded .deb files (bootstrap/chroot/binary apt runs).
+    # Cache downloaded .deb files (bootstrap/chroot/binary apt runs). Caches by the following hierarchy: specific overlay config -> main overlay config -> os/packages 
     - name: Restore cached live-build packages
       id: cache-lb-debs
       uses: actions/cache/restore@v4
@@ -95,13 +95,14 @@ runs:
           ${{ inputs.path }}/.build/lb/cache/packages.bootstrap
           ${{ inputs.path }}/.build/lb/cache/packages.chroot
           ${{ inputs.path }}/.build/lb/cache/packages.binary
-        key: lb-debs-${{ runner.os }}-${{ hashFiles('overlays/*/packages/**/*.yaml*') }}-${{ hashFiles('overlays/*/config.yaml') }}-${{ hashFiles('os/config.yaml') }}-${{ hashFiles('os/packages/**/*.yaml') }}
 
-        restore-keys: |
-          lb-debs-${{ runner.os }}-${{ hashFiles('overlays/*/packages/**/*.yaml*') }}-${{ hashFiles('overlays/*/config.yaml') }}-${{ hashFiles('os/config.yaml') }}-
-          lb-debs-${{ runner.os }}-${{ hashFiles('overlays/*/packages/**/*.yaml*') }}-${{ hashFiles('overlays/*/config.yaml') }}-
-          lb-debs-${{ runner.os }}-${{ hashFiles('overlays/*/packages/**/*.yaml*') }}-
-          lb-debs-${{ runner.os }}-
+      key: lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/packages/**/*.yaml', inputs.path)) }}
+
+      restore-keys: |
+        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-
+        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-
+        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-
+        lb-debs-${{ runner.os }}-
 
     # Allow caching of whole-directory chroot snapshots (LB_CACHE_STAGES). live-build's restore is
     # content-blind (plain cp -a, no invalidation check), so no restore-keys

--- a/action.yml
+++ b/action.yml
@@ -139,10 +139,8 @@ runs:
         sudo mkdir -p "$target"
         sudo tar --extract --preserve-permissions --file "$RUNNER_TEMP/lb-chroot.tar" --directory "$target"
 
-    # Layer 1 (survived): before/after .deb counts+sizes per cache dir.
-    # Layer 2 (recognized): before/after live-build stamp listing, diffed.
-    # Layer 3 (consumed): apt's own "Need to get"/"Fetched" bytes from build.log.
     - name: Verify package cache before build
+      if: runner.debug == '1'
       shell: bash
       run: |
         echo "Before make build:"
@@ -153,6 +151,7 @@ runs:
         done
         ls ${{ inputs.path }}/.build/lb/.build/ 2>/dev/null | sort > "$RUNNER_TEMP/lb-stamps-before.txt" || true
 
+
     - name: Live Build
       working-directory: ./${{ inputs.path }}
       shell: bash
@@ -160,7 +159,7 @@ runs:
 
     - name: Verify package cache after build
       working-directory: ./${{ inputs.path }}
-      if: always()
+      if: always() && runner.debug == '1'
       shell: bash
       run: |
         echo "After make build:"
@@ -180,7 +179,7 @@ runs:
         grep -c '^I: Retrieving ' .build/lb/build.log 2>/dev/null || true
 
     - name: Upload cache verification artifacts
-      if: always()
+      if: always() && runner.debug == '1'
       uses: actions/upload-artifact@v4
       with:
         name: lb-cache-verification
@@ -189,7 +188,6 @@ runs:
           ${{ runner.temp }}/lb-stamps-after.txt
           ${{ inputs.path }}/.build/lb/build.log
         if-no-files-found: ignore
-
 
     - name: Enable execute and read for package cache files # Allows unprivileged cache action to save packages.* directly
       shell: bash
@@ -243,13 +241,6 @@ runs:
       with:
         path: ${{ runner.temp }}/lb-chroot.tar
         key: ${{ steps.cache-lb-chroot.outputs.cache-primary-key }}
-
-    # - name: Recursively list all directories # Temporary command to list all possible files
-    #   working-directory: .
-    #   shell: bash
-    #   run: |
-    #     sudo apt-get install -y tree
-    #     tree -a
 
     - name: Output ISO Path
       id: iso-path

--- a/action.yml
+++ b/action.yml
@@ -139,10 +139,57 @@ runs:
         sudo mkdir -p "$target"
         sudo tar --extract --preserve-permissions --file "$RUNNER_TEMP/lb-chroot.tar" --directory "$target"
 
+    # Layer 1 (survived): before/after .deb counts+sizes per cache dir.
+    # Layer 2 (recognized): before/after live-build stamp listing, diffed.
+    # Layer 3 (consumed): apt's own "Need to get"/"Fetched" bytes from build.log.
+    - name: Verify package cache before build
+      shell: bash
+      run: |
+        echo "Before make build:"
+        for pkg in packages.bootstrap packages.chroot packages.binary; do
+          dir="${{ inputs.path }}/.build/lb/cache/$pkg"
+          echo "$pkg: $(find "$dir" -maxdepth 1 -type f -name '*.deb' 2>/dev/null | wc -l) debs"
+          du -sh "$dir" 2>/dev/null || true
+        done
+        ls ${{ inputs.path }}/.build/lb/.build/ 2>/dev/null | sort > "$RUNNER_TEMP/lb-stamps-before.txt" || true
+
     - name: Live Build
       working-directory: ./${{ inputs.path }}
       shell: bash
       run: sudo env "PATH=$PATH" make build
+
+    - name: Verify package cache after build
+      working-directory: ./${{ inputs.path }}
+      if: always()
+      shell: bash
+      run: |
+        echo "After make build:"
+        for pkg in packages.bootstrap packages.chroot packages.binary; do
+          dir=".build/lb/cache/$pkg"
+          echo "$pkg: $(find "$dir" -maxdepth 1 -type f -name '*.deb' 2>/dev/null | wc -l) debs"
+          du -sh "$dir" 2>/dev/null || true
+        done
+
+        ls .build/lb/.build/ 2>/dev/null | sort > "$RUNNER_TEMP/lb-stamps-after.txt" || true
+        echo "Stamp diff (before vs after):"
+        diff -u "$RUNNER_TEMP/lb-stamps-before.txt" "$RUNNER_TEMP/lb-stamps-after.txt" || true
+
+        echo "Package consumption evidence from build.log:"
+        grep -E 'Need to get|Fetched' .build/lb/build.log 2>/dev/null || true
+        echo "Debootstrap retrieving count:"
+        grep -c '^I: Retrieving ' .build/lb/build.log 2>/dev/null || true
+
+    - name: Upload cache verification artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: lb-cache-verification
+        path: |
+          ${{ runner.temp }}/lb-stamps-before.txt
+          ${{ runner.temp }}/lb-stamps-after.txt
+          ${{ inputs.path }}/.build/lb/build.log
+        if-no-files-found: ignore
+
 
     - name: Enable execute and read for package cache files # Allows unprivileged cache action to save packages.* directly
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -95,8 +95,12 @@ runs:
           ${{ inputs.path }}/.build/lb/cache/packages.bootstrap
           ${{ inputs.path }}/.build/lb/cache/packages.chroot
           ${{ inputs.path }}/.build/lb/cache/packages.binary
-        key: lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/**', inputs.path)) }}
+        key: lb-debs-${{ runner.os }}-${{ hashFiles('overlays/*/packages/**/*.yaml*') }}-${{ hashFiles('overlays/*/config.yaml') }}-${{ hashFiles('os/config.yaml') }}-${{ hashFiles('os/packages/**/*.yaml') }}
+
         restore-keys: |
+          lb-debs-${{ runner.os }}-${{ hashFiles('overlays/*/packages/**/*.yaml*') }}-${{ hashFiles('overlays/*/config.yaml') }}-${{ hashFiles('os/config.yaml') }}-
+          lb-debs-${{ runner.os }}-${{ hashFiles('overlays/*/packages/**/*.yaml*') }}-${{ hashFiles('overlays/*/config.yaml') }}-
+          lb-debs-${{ runner.os }}-${{ hashFiles('overlays/*/packages/**/*.yaml*') }}-
           lb-debs-${{ runner.os }}-
 
     # Allow caching of whole-directory chroot snapshots (LB_CACHE_STAGES). live-build's restore is

--- a/action.yml
+++ b/action.yml
@@ -122,6 +122,10 @@ runs:
       shell: bash
       run: sudo env "PATH=$PATH" make build
 
+    - name: Enable execute and read for cache files # Allows unprivielged cache action to save files
+      shell: bash
+      run: sudo chmod -R a+rX ${{ inputs.path }}/.build/lb/cache
+
     - name: Save live-build packages cache
       uses: actions/cache/save@v4
       with:

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ runs:
       id: cache-lb-chroot
       uses: actions/cache/restore@v4
       with:
-        path: ${{ inputs.path }}/lb/cache/chroot
+        path: ${{ inputs.path }}/.build/lb/cache/chroot
         key: lb-chroot-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path), format('{0}/overlays/**', inputs.path)) }}
 
     - name: Live Build
@@ -126,21 +126,21 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: |
-          ${{ inputs.path }}/lb/cache/packages.bootstrap
-          ${{ inputs.path }}/lb/cache/packages.chroot
-          ${{ inputs.path }}/lb/cache/packages.binary
+          ${{ inputs.path }}/.build/lb/cache/packages.bootstrap
+          ${{ inputs.path }}/.build/lb/cache/packages.chroot
+          ${{ inputs.path }}/.build/lb/cache/packages.binary
         key: ${{ steps.cache-lb-debs.outputs.cache-primary-key }}
 
     - name: Save bootstrap stage cache
       uses: actions/cache/save@v4
       with:
-        path: ${{ inputs.path }}/lb/cache/bootstrap
+        path: ${{ inputs.path }}/.build/lb/cache/bootstrap
         key: ${{ steps.cache-lb-bootstrap.outputs.cache-primary-key }}
 
     - name: Save chroot stage cache
       uses: actions/cache/save@v4
       with:
-        path: ${{ inputs.path }}/lb/cache/chroot
+        path: ${{ inputs.path }}/.build/lb/cache/chroot
         key: ${{ steps.cache-lb-chroot.outputs.cache-primary-key }}
 
     - name: Recursively list all directories # Temporary command to list all possible files

--- a/action.yml
+++ b/action.yml
@@ -86,14 +86,10 @@ runs:
         . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
 
-    - name: Live Build
-      working-directory: ./${{ inputs.path }}
-      shell: bash
-      run: sudo env "PATH=$PATH" make build
-
-    # Cache downloaded .deb files (bootstrap/chroot/binary apt runs). 
-    - name: Load cached live-build packages
-      uses: actions/cache@v4
+    # Cache downloaded .deb files (bootstrap/chroot/binary apt runs).
+    - name: Restore cached live-build packages
+      id: cache-lb-debs
+      uses: actions/cache/restore@v4
       with:
         path: |
           ${{ inputs.path }}/lb/cache/packages.bootstrap
@@ -107,17 +103,45 @@ runs:
     # content-blind (plain cp -a, no invalidation check), so no restore-keys
     # an exact-match miss just means a normal build, a fuzzy hit would silently
     # skip real work with stale content.
-    - name: Load cached bootstrap stage
-      uses: actions/cache@v4
+    - name: Restore cached bootstrap stage
+      id: cache-lb-bootstrap
+      uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.path }}/lb/cache/bootstrap
         key: lb-bootstrap-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}
 
-    - name: Load cached chroot stage
-      uses: actions/cache@v4
+    - name: Restore cached chroot stage
+      id: cache-lb-chroot
+      uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.path }}/lb/cache/chroot
         key: lb-chroot-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path), format('{0}/overlays/**', inputs.path)) }}
+
+    - name: Live Build
+      working-directory: ./${{ inputs.path }}
+      shell: bash
+      run: sudo env "PATH=$PATH" make build
+
+    - name: Save live-build packages cache
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ inputs.path }}/lb/cache/packages.bootstrap
+          ${{ inputs.path }}/lb/cache/packages.chroot
+          ${{ inputs.path }}/lb/cache/packages.binary
+        key: ${{ steps.cache-lb-debs.outputs.cache-primary-key }}
+
+    - name: Save bootstrap stage cache
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ inputs.path }}/lb/cache/bootstrap
+        key: ${{ steps.cache-lb-bootstrap.outputs.cache-primary-key }}
+
+    - name: Save chroot stage cache
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ inputs.path }}/lb/cache/chroot
+        key: ${{ steps.cache-lb-chroot.outputs.cache-primary-key }}
 
     - name: Recursively list all directories # Temporary command to list all possible files
       working-directory: .

--- a/action.yml
+++ b/action.yml
@@ -104,32 +104,75 @@ runs:
           lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-
           lb-debs-${{ runner.os }}-
 
-    # Allow caching of whole-directory chroot snapshots (LB_CACHE_STAGES). live-build's restore is
-    # content-blind (plain cp -a, no invalidation check), so no restore-keys
-    # an exact-match miss just means a normal build, a fuzzy hit would silently
-    # skip real work with stale content.
-    - name: Restore cached bootstrap stage
+    # Cache bootstrap and chroot stages manually with priveleged tar so ownership, permissions, and device nodes work.
+    - name: Restore cached bootstrap stage archive
       id: cache-lb-bootstrap
       uses: actions/cache/restore@v4
       with:
-        path: ${{ inputs.path }}/.build/lb/cache/bootstrap
-        key: lb-bootstrap-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}
+        path: ${{ runner.temp }}/lb-bootstrap.tar
+        key: lb-bootstrap-v2-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}
 
-    - name: Restore cached chroot stage
+    - name: Extract cached bootstrap stage
+      if: steps.cache-lb-bootstrap.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        target="${{ inputs.path }}/.build/lb/cache/bootstrap"
+        sudo rm -rf "$target"
+        sudo mkdir -p "$target"
+        sudo tar --extract --preserve-permissions --file "$RUNNER_TEMP/lb-bootstrap.tar" --directory "$target"
+
+    - name: Restore cached chroot stage archive
       id: cache-lb-chroot
       uses: actions/cache/restore@v4
       with:
-        path: ${{ inputs.path }}/.build/lb/cache/chroot
-        key: lb-chroot-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path), format('{0}/overlays/**', inputs.path)) }}
+        path: ${{ runner.temp }}/lb-chroot.tar
+        key: lb-chroot-v2-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path), format('{0}/overlays/**', inputs.path)) }}
+
+    - name: Extract cached chroot stage
+      if: steps.cache-lb-chroot.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        target="${{ inputs.path }}/.build/lb/cache/chroot"
+        sudo rm -rf "$target"
+        sudo mkdir -p "$target"
+        sudo tar --extract --preserve-permissions --file "$RUNNER_TEMP/lb-chroot.tar" --directory "$target"
 
     - name: Live Build
       working-directory: ./${{ inputs.path }}
       shell: bash
       run: sudo env "PATH=$PATH" make build
 
-    - name: Enable execute and read for cache files # Allows unprivielged cache action to save files
+    - name: Enable execute and read for package cache files # Allows unprivileged cache action to save packages.* directly
       shell: bash
-      run: sudo chmod -R a+rX ${{ inputs.path }}/.build/lb/cache
+      run: |
+        sudo chmod -R a+rX \
+          ${{ inputs.path }}/.build/lb/cache/packages.bootstrap \
+          ${{ inputs.path }}/.build/lb/cache/packages.chroot \
+          ${{ inputs.path }}/.build/lb/cache/packages.binary
+
+    - name: Archive bootstrap stage
+      if: success() && steps.cache-lb-bootstrap.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        source="${{ inputs.path }}/.build/lb/cache/bootstrap"
+        test -d "$source"
+        sudo tar --create --preserve-permissions --one-file-system \
+          --file "$RUNNER_TEMP/lb-bootstrap.tar" --directory "$source" .
+        sudo chmod a+r "$RUNNER_TEMP/lb-bootstrap.tar"
+
+    - name: Archive chroot stage
+      if: success() && steps.cache-lb-chroot.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        source="${{ inputs.path }}/.build/lb/cache/chroot"
+        test -d "$source"
+        sudo tar --create --preserve-permissions --one-file-system \
+          --file "$RUNNER_TEMP/lb-chroot.tar" --directory "$source" .
+        sudo chmod a+r "$RUNNER_TEMP/lb-chroot.tar"
 
     - name: Save live-build packages cache
       uses: actions/cache/save@v4
@@ -141,15 +184,17 @@ runs:
         key: ${{ steps.cache-lb-debs.outputs.cache-primary-key }}
 
     - name: Save bootstrap stage cache
+      if: success() && steps.cache-lb-bootstrap.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        path: ${{ inputs.path }}/.build/lb/cache/bootstrap
+        path: ${{ runner.temp }}/lb-bootstrap.tar
         key: ${{ steps.cache-lb-bootstrap.outputs.cache-primary-key }}
 
     - name: Save chroot stage cache
+      if: success() && steps.cache-lb-chroot.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        path: ${{ inputs.path }}/.build/lb/cache/chroot
+        path: ${{ runner.temp }}/lb-chroot.tar
         key: ${{ steps.cache-lb-chroot.outputs.cache-primary-key }}
 
     # - name: Recursively list all directories # Temporary command to list all possible files

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
 
-    # Cache downloaded .deb files (bootstrap/chroot/binary apt runs). Caches by the following hierarchy: specific overlay config -> main overlay config -> os/packages 
+    # Cache downloaded .deb files (bootstrap/chroot/binary apt runs). Caches by the following hierarchy: overlay packages -> main overlay config -> specific overlay configs -> os/packages 
     - name: Restore cached live-build packages
       id: cache-lb-debs
       uses: actions/cache/restore@v4
@@ -96,11 +96,11 @@ runs:
           ${{ inputs.path }}/.build/lb/cache/packages.chroot
           ${{ inputs.path }}/.build/lb/cache/packages.binary
 
-      key: lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/packages/**/*.yaml', inputs.path)) }}
+      key: lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/packages/**/*.yaml', inputs.path)) }}
 
       restore-keys: |
-        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-
-        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-
+        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-
+        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-
         lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-
         lb-debs-${{ runner.os }}-
 

--- a/action.yml
+++ b/action.yml
@@ -92,9 +92,9 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: |
-          ${{ inputs.path }}/lb/cache/packages.bootstrap
-          ${{ inputs.path }}/lb/cache/packages.chroot
-          ${{ inputs.path }}/lb/cache/packages.binary
+          ${{ inputs.path }}/.build/lb/cache/packages.bootstrap
+          ${{ inputs.path }}/.build/lb/cache/packages.chroot
+          ${{ inputs.path }}/.build/lb/cache/packages.binary
         key: lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/**', inputs.path)) }}
         restore-keys: |
           lb-debs-${{ runner.os }}-
@@ -107,7 +107,7 @@ runs:
       id: cache-lb-bootstrap
       uses: actions/cache/restore@v4
       with:
-        path: ${{ inputs.path }}/lb/cache/bootstrap
+        path: ${{ inputs.path }}/.build/lb/cache/bootstrap
         key: lb-bootstrap-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}
 
     - name: Restore cached chroot stage

--- a/action.yml
+++ b/action.yml
@@ -96,13 +96,13 @@ runs:
           ${{ inputs.path }}/.build/lb/cache/packages.chroot
           ${{ inputs.path }}/.build/lb/cache/packages.binary
 
-      key: lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/packages/**/*.yaml', inputs.path)) }}
+        key: lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/os/packages/**/*.yaml', inputs.path)) }}
 
-      restore-keys: |
-        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-
-        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-
-        lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-
-        lb-debs-${{ runner.os }}-
+        restore-keys: |
+          lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-${{ hashFiles(format('{0}/overlays/*/config.yaml', inputs.path)) }}-
+          lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}-
+          lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/*/packages/**/*.yaml*', inputs.path)) }}-
+          lb-debs-${{ runner.os }}-
 
     # Allow caching of whole-directory chroot snapshots (LB_CACHE_STAGES). live-build's restore is
     # content-blind (plain cp -a, no invalidation check), so no restore-keys

--- a/action.yml
+++ b/action.yml
@@ -147,12 +147,12 @@ runs:
         path: ${{ inputs.path }}/.build/lb/cache/chroot
         key: ${{ steps.cache-lb-chroot.outputs.cache-primary-key }}
 
-    - name: Recursively list all directories # Temporary command to list all possible files
-      working-directory: .
-      shell: bash
-      run: |
-        sudo apt-get install -y tree
-        tree -a
+    # - name: Recursively list all directories # Temporary command to list all possible files
+    #   working-directory: .
+    #   shell: bash
+    #   run: |
+    #     sudo apt-get install -y tree
+    #     tree -a
 
     - name: Output ISO Path
       id: iso-path

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,34 @@ runs:
       shell: bash
       run: sudo env "PATH=$PATH" make build
 
+    # Cache downloaded .deb files (bootstrap/chroot/binary apt runs). 
+    - name: Load cached live-build packages
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ inputs.path }}/lb/cache/packages.bootstrap
+          ${{ inputs.path }}/lb/cache/packages.chroot
+          ${{ inputs.path }}/lb/cache/packages.binary
+        key: lb-debs-${{ runner.os }}-${{ hashFiles(format('{0}/overlays/**', inputs.path)) }}
+        restore-keys: |
+          lb-debs-${{ runner.os }}-
+
+    # Allow caching of whole-directory chroot snapshots (LB_CACHE_STAGES). live-build's restore is
+    # content-blind (plain cp -a, no invalidation check), so no restore-keys
+    # an exact-match miss just means a normal build, a fuzzy hit would silently
+    # skip real work with stale content.
+    - name: Load cached bootstrap stage
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.path }}/lb/cache/bootstrap
+        key: lb-bootstrap-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path)) }}
+
+    - name: Load cached chroot stage
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.path }}/lb/cache/chroot
+        key: lb-chroot-${{ runner.os }}-${{ hashFiles(format('{0}/os/config.yaml', inputs.path), format('{0}/overlays/**', inputs.path)) }}
+
     - name: Recursively list all directories # Temporary command to list all possible files
       working-directory: .
       shell: bash


### PR DESCRIPTION
This PR aims to add livebuild caching.

Notes:
* The test release/v2 workflows are updated to support targeting a specific checkout commit
* Currently only the chroot, binary, and packages are cached.
* Clayrisser Linux Factory's https://github.com/clayrisser/linux-factory/blob/0ff274013fe65ffc474a2d5d24da90e00fa4a6fe/src/stages/prepare.py#L56 `initialize_lb()` will force clear the cache before build. This unfortunately means caching won't work until manual fixes are moved upstream directly to the linux factory repositories. 
* Worst-case performance increases seems to be around ~1-2 minutes if only the packages were cached
* Added debug logging for future cases where caching fails